### PR TITLE
feat(style): add table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The `index.md` page should use layout `home`, which is the layout that displays 
 
 Another thing you can do to customize the index page is show the description of your blog between the title and the menu. To do this, just edit `config.toml` and change `params.theme_config.show_description` to `true`.
 
+### Adding table of contents
+
+You can add a table of contents by supplying the `toc: true` param to your post front matter. If you want a border around it you can also set `tocBorder: true`. The toc style behavior is handled by Goldmark and the defaults can be found in the `config.toml` file.
+
 ### Pro tips
 
 #### Dark mode for images

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -51,6 +51,11 @@ li { margin: 0.4rem 0; }
   padding: 4rem 2rem;
 }
 
+.toc {
+  border: thin solid black;
+  padding: 1rem;
+}
+
 hr {
   text-align: center;
   border: 0;

--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,10 @@
     noHl = false
     style = 'rrt'
     tabWidth = 4
+  [markup.tableOfContents]
+    startLevel = 2
+    endLevel = 3
+    ordered = false
 
 [params]
   [params.theme_config]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
 
     <h1>{{ .Title }}</h1>
 
-    {{if .Params.toc }}
+    {{ if .Params.toc }}
         <aside {{ if .Params.tocBorder }} class="toc" {{ end }}>
             {{ .TableOfContents }}
         </aside>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,6 +10,12 @@
 
     <h1>{{ .Title }}</h1>
 
+    {{if .Params.toc }}
+        <aside {{ if .Params.tocBorder }} class="toc" {{ end }}>
+            {{ .TableOfContents }}
+        </aside>
+    {{ end }}
+
     {{ .Content }}
 </article>
 {{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -10,7 +10,7 @@
 
     <h1>{{ .Title }}</h1>
 
-    {{if .Params.toc }}
+    {{ if .Params.toc }}
         <aside {{ if .Params.tocBorder }} class="toc" {{ end }}>
             {{ .TableOfContents }}
         </aside>

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -10,6 +10,12 @@
 
     <h1>{{ .Title }}</h1>
 
+    {{if .Params.toc }}
+        <aside {{ if .Params.tocBorder }} class="toc" {{ end }}>
+            {{ .TableOfContents }}
+        </aside>
+    {{ end }}
+
     {{ .Content }}
 </article>
 {{ end }}


### PR DESCRIPTION
Hugo offers table of contents generation out of the box, so I thought it's a good idea to add support for that. I've added two params for setting the toc and for setting a border around it.

I couldn't figure out which design looked better. I think both fit stylistically, so I'm just leaving the option to the content creator. Here's how they look.

**No border**
Front matter param: `toc: true`
![image](https://user-images.githubusercontent.com/5088351/232048519-71f84ec1-021e-4114-9923-e3270e5a589c.png)

**With border**
Front matter params: `toc: true` and `tocBorder: true`
![image](https://user-images.githubusercontent.com/5088351/232048657-f254a155-518d-448a-98e1-749fa6472fe6.png)

Let me know your thoughts!